### PR TITLE
Add 'javascript 6to5' syntax name

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class ESLint(Linter):
 
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html', 'javascriptnext')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript 6to5')
     cmd = 'eslint --format=compact --stdin'
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
To lint files using [6to5-sublime](https://github.com/6to5/6to5-sublime)'s syntax, now that we are starting to see real [ES6](http://eslint.org/blog/2015/01/eslint-0.12.0-released/) support.