### PR TITLE
Inherit from NodeLinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,14 +10,15 @@
 
 """This module exports the ESLint plugin class."""
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import NodeLinter
 
 
-class ESLint(Linter):
+class ESLint(NodeLinter):
 
     """Provides an interface to the eslint executable."""
 
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript 6to5')
+    npm_name = 'eslint'
     cmd = 'eslint --format=compact --stdin'
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
By inheriting from `NodeLinter`, the `ESLint` plugin can use a locally installed version of `eslint`.

This requires the fix in SublimeLinter/SublimeLinter3#179 to use the locally installed `eslint`.  Without that change, the linter will still work with a globally installed `eslint`.

The benefit of this is that a project can depend on a specific version of `eslint` and their editor will lint with the same.