### PR TITLE
Rename 6to5 to babel

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class ESLint(NodeLinter):
 
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html', 'javascriptnext', 'javascript 6to5')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)')
     npm_name = 'eslint'
     cmd = 'eslint --format=compact --stdin'
     version_args = '--version'


### PR DESCRIPTION
Hey @roadhump, we changed the name of 6to5 to babel. I'm waiting on https://github.com/wbond/package_control_channel/pull/4099 before I merge https://github.com/6to5/6to5-sublime/pull/38. So, I'll ping you again when this PR should be merged. Thank you!