### PR TITLE
Update the syntax list to include 'javascript (jsx)'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class ESLint(NodeLinter):
     cmd = 'eslint --format=compact --stdin'
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.9.0'
+    version_requirement = '>= 0.12.0'
     regex = (
         r'^.+?: line (?P<line>\d+), col (?P<col>\d+), '
         r'(?:(?P<error>Error)|(?P<warning>Warning)) - '

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class ESLint(NodeLinter):
 
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)')
     npm_name = 'eslint'
     cmd = 'eslint --format=compact --stdin'
     version_args = '--version'


### PR DESCRIPTION
Since ESLint >= 1.2.0 supports linting [JSX](http://facebook.github.io/jsx/) files it would be nice if SublimeLinter-eslint played well together with the JavaScript (JSX) syntax as defined by [sublime-react](https://github.com/reactjs/sublime-react). This change adds 'javascript (jsx)' to the list of supported syntaxes, which seems to do the job.

I didn't dare to bump the minimum required ESLint version to 1.2.0 (ESlint's JSX parsing is off by default anyway).