### PR TITLE
Remove --stdin-filename

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class ESLint(NodeLinter):
 
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)')
     npm_name = 'eslint'
-    cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@')
+    cmd = ('eslint', '--format', 'compact', '--stdin', '@')
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.20.0'


### PR DESCRIPTION
This fixes following error with eslint v0.19.0
SublimeLinter: eslint: users.js ['/Users/tom/Code/Sandbox/tomflux/node_modules/.bin/eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@'] 
SublimeLinter: eslint output:
Invalid option '--stdin-filename' - perhaps you meant '--stdin'?