### PR TITLE
Change --stdin-filename to relative to check by .eslintignore (fixes #46)

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,6 +10,8 @@
 
 """This module exports the ESLint plugin class."""
 
+import sublime
+import os
 from SublimeLinter.lint import NodeLinter
 
 
@@ -19,7 +21,7 @@ class ESLint(NodeLinter):
 
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)')
     npm_name = 'eslint'
-    cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@')
+    cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '__RELATIVE_TO_FOLDER__')
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.20.0'
@@ -32,3 +34,31 @@ class ESLint(NodeLinter):
     selectors = {
         'html': 'source.js.embedded.html'
     }
+
+    def split_match(self, match):
+        """
+        Extract and return values from match.
+
+        We override this method to silent warning by .eslintignore settings.
+
+        """
+
+        match, line, col, error, warning, message, near = super().split_match(match)
+        if message and message == 'File ignored because of your .eslintignore file. Use --no-ignore to override.':
+            return match, None, None, None, None, '', None
+
+        return match, line, col, error, warning, message, near
+
+    def communicate(self, cmd, code=None):
+        """Run an external executable using stdin to pass code and return its output."""
+        
+        window = self.view.window()
+        vars = window.extract_variables()
+        relfilename = os.path.relpath(self.filename, vars['folder'])
+
+        if '__RELATIVE_TO_FOLDER__' in cmd:
+            cmd[cmd.index('__RELATIVE_TO_FOLDER__')] = relfilename
+        elif not code:
+            cmd.append(self.filename)
+
+        return super().communicate(cmd, code)


### PR DESCRIPTION
I suppose that the most common scenario is to have one `.eslintignore` at the root of project and  execute `eslint .` or `eslint folder/file` there. That is the behavior I keep in mind to make `.eslintignore` settings work for plugin. That's why now plugin executes

```
cat /path/to/projectFolder/projectSubFolder/file | eslint --stdin --stdin-filename projectSubFolder/file
```

instead of

```
cat /path/to/projectFolder/projectSubFolder/file | eslint --stdin --stdin-filename /path/tp/projectFolder/projectSubFolder/file
```
or 
```
cat /path/to/projectFolder/projectSubFolder/file | eslint --stdin --stdin-filename file
```

It makes to work the default `.eslintignore` option `node_modules/**`.

To revert this behavior (if full name of file in `--stdin-filename` is critical) add 
```
{
    "linters": {
        "eslint": {
            "args": ["--stdin-filename", "@"]
        }
    }
}
```

to your `.sublimelinterrc` file