### PR TITLE
Add jsx-real syntax to supported syntaxes

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class ESLint(NodeLinter):
 
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)', 'jsx-real')
     npm_name = 'eslint'
     cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '__RELATIVE_TO_FOLDER__')
     version_args = '--version'


### PR DESCRIPTION
Work around for sublimelinter/sublimelinter3#263 that caused eslint to fail when using JSX syntax.