### PR TITLE
SUBLIME_ESLINT_FOLDERS and SUBLIME_ESLINT_FILE env added

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,6 +23,7 @@ class ESLint(NodeLinter):
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)', 'jsx-real')
     npm_name = 'eslint'
     cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '__RELATIVE_TO_FOLDER__')
+    env = {}
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.20.0'
@@ -79,15 +80,18 @@ class ESLint(NodeLinter):
         if '__RELATIVE_TO_FOLDER__' in cmd:
 
             relfilename = self.filename
+            window = self.view.window()
 
             if int(sublime.version()) >= 3080:
-                window = self.view.window()
                 vars = window.extract_variables()
 
                 if 'folder' in vars:
                     relfilename = os.path.relpath(self.filename, vars['folder'])
 
             cmd[cmd.index('__RELATIVE_TO_FOLDER__')] = relfilename
+
+            self.env['SUBLIME_ESLINT_FOLDERS'] = ';'.join(window.folders())
+            self.env['SUBLIME_ESLINT_FILE'] = relfilename
 
         elif not code:
             cmd.append(self.filename)


### PR DESCRIPTION
Hi Aliaksei!

[I'm using the docker container for eslint](https://github.com/kkamkou/docker-applications/blob/master/eslint.sh). The only problem is to extract the root folder from the sublime tree. This path is required for .eslintrc detection.

What I did is kind of sharing the information using the ENV variables. Please, review.