### PR TITLE
add support for explicit per-project executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Check if you already have it installed, please.
 
 Try changing your syntax from JSX to Babel > Javascript. ([ref issue](https://github.com/roadhump/SublimeLinter-eslint/issues/106))
 
+##### I want to use a specific ESLint executable for each project
+
+You can specify the specific `eslint` executable you want to use in your project file by setting a `cmd` value for the eslint linter.
+
+```
+{
+    "linters": {
+        "eslint": {
+            "cmd": "${project}/node_modules/gruntify-eslint/node_modules/.bin/eslint"
+        }
+    }
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/messages.json
+++ b/messages.json
@@ -8,5 +8,6 @@
     "1.5.0": "messages/1.5.0.txt",
     "1.6.0": "messages/1.6.0.txt",
     "1.7.0": "messages/1.7.0.txt",
-    "1.9.0": "messages/1.9.0.txt"
+    "1.9.0": "messages/1.9.0.txt",
+    "1.10.0": "messages/1.10.0.txt"
 }

--- a/messages/1.10.0.txt
+++ b/messages/1.10.0.txt
@@ -1,0 +1,15 @@
+# SublimeLinter-eslint
+
+v1.10.0
+
+Allow for explicitly defined per-project executables.
+
+```
+{
+    "linters": {
+        "eslint": {
+            "cmd": "${project}/node_modules/gruntify-eslint/node_modules/.bin/eslint"
+        }
+    }
+}
+```


### PR DESCRIPTION
- add support for explicitly specifying per-project executables
- update README file with FAQ example of new functionality
- new version message file
- resolves situations that may occur when eslint is not a direct dependency of the project NodeLinter is not able to locate a binary for it

Please let me know if you need anymore background for this change.
