### PR TITLE
__RELATIVE_TO_FOLDER__ no longer needed for ESLint 2.0

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class ESLint(NodeLinter):
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)',
               'javascript (jsx)', 'jsx-real', 'Vue Component')
     npm_name = 'eslint'
-    cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '__RELATIVE_TO_FOLDER__')
+    cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@')
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.0.0'


### PR DESCRIPTION
`.eslintignore` path handling is improved in ESLint 2.x, no longer requiring path to be set relative to the `.eslintignore` directory. 

Might fix #127, but I was not able to replicate.

Users of `eslint-plugin-import` would no longer need to work around the filename rewriting with [this](https://www.npmjs.com/package/eslint-plugin-import#sublimelinter-eslint), also.

~~This will break ESLint 1.0 ignore compatibility, though. Not sure how you would like to handle that. I can imagine keeping the `if __RELATIVE_TO_FOLDER__ in cmd:` block, but defaulting to `'@'` instead, maybe? (assuming you'd like to maintain compatibility with both)~~

I went ahead and rewrote the commit to just switch the default `--stdin-filename` from `__RELATIVE_TO_FOLDER__` to `@`, but kept the behavior so users of ESLint 1.x could spec it via `.sublimelinterrc`, etc. I think this strikes a better balance of backwards compatibility.